### PR TITLE
[FIX] CardList에 DataModal 추가

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { RatingBadge } from "../RatingBadge";
 import classes from "./Card.module.css";
 import Image from "next/image";
@@ -17,13 +19,14 @@ type Conference = {
 
 type CardProps = {
   item: Conference;
+  onClick?: () => void;
 };
 
-export function Card({ item }: CardProps) {
+export function Card({ item, onClick }: CardProps) {
   const deviation = Number((item.proportion - item.average).toFixed(2));
 
   return (
-    <div className={classes.cardContainer}>
+    <div className={classes.cardContainer} onClick={onClick}>
       <div className={classes.cardTitle}>{item.acronym}</div>
       <div className={`${classes.gap} ${classes.ps}`}>
         {item.ratings.map((rating, index) => (
@@ -41,7 +44,14 @@ export function Card({ item }: CardProps) {
         />
         <div className={classes.proportion}>{`${item.proportion}%`}</div>
       </div>
-      <div>전체 평균 대비 {Math.abs(deviation)}% {deviation > 0 ? <span className={classes.redArrow}>↑</span> : <span className={classes.blueArrow}>↓</span>}</div>
+      <div>
+        전체 평균 대비 {Math.abs(deviation)}%{" "}
+        {deviation > 0 ? (
+          <span className={classes.redArrow}>↑</span>
+        ) : (
+          <span className={classes.blueArrow}>↓</span>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/CardList/CardList.tsx
+++ b/src/components/CardList/CardList.tsx
@@ -1,7 +1,10 @@
-'use client';
+"use client";
+
 import { useState } from "react";
 import classes from "./CardList.module.css";
 import { Card } from "../Card";
+import { useDisclosure } from "@/hook/useDisclosure";
+import { DataModal } from "../DataModal";
 
 type Rating = {
   year: number;
@@ -32,16 +35,18 @@ const dummyPage1: Page = {
   data: Array.from({ length: 12 }, (_, index) => {
     return {
       id: index,
-      acronym: 'SOSP',
-      ratings: [{
-        year: 2024,
-        grade: 'top',
-      }],
+      acronym: "SOSP",
+      ratings: [
+        {
+          year: 2024,
+          grade: "top",
+        },
+      ],
       proportion: 16.4,
       average: 12.3,
-    }
-  })
-}
+    };
+  }),
+};
 
 const dummyPage2: Page = {
   pageNumber: 2,
@@ -51,19 +56,23 @@ const dummyPage2: Page = {
   data: Array.from({ length: 12 }, (_, index) => {
     return {
       id: index,
-      acronym: 'SECOND',
-      ratings: [{
-        year: 2023,
-        grade: 'excellence',
-      }],
+      acronym: "SECOND",
+      ratings: [
+        {
+          year: 2023,
+          grade: "excellence",
+        },
+      ],
       proportion: 12.4,
       average: 13.3,
-    }
-  })
-}
+    };
+  }),
+};
 
 export function CardList() {
   const [data, setData] = useState(dummyPage1.data);
+  const [conferenceId, setConferenceId] = useState(0);
+  const { open, setOpen, close } = useDisclosure();
 
   return (
     <div className={classes.root}>
@@ -72,15 +81,20 @@ export function CardList() {
         <span> 논문비율 순 </span>
       </div>
       <div className={classes.row}>
-        {
-          data.map((conference, index) => {
-            return (
-              <div key={index} className={classes.column}>
-                <Card item={conference} />
-              </div>
-            )
-          })
-        }
+        {data.map((conference, index) => {
+          return (
+            <div key={index} className={classes.column}>
+              <Card
+                item={conference}
+                onClick={() => {
+                  setConferenceId(conference.id);
+                  setOpen(true);
+                }}
+              />
+            </div>
+          );
+        })}
+        <DataModal open={open} onClose={close} conferenceId={conferenceId} withCloseButton />
       </div>
     </div>
   );


### PR DESCRIPTION
## 스크린샷
<img width="1501" alt="스크린샷 2024-09-26 오후 6 51 13" src="https://github.com/user-attachments/assets/4cd6525d-99a4-4c94-bf50-3d8434debdc0">

## 작업 내역
CardList의 Card를 클릭하면 모달이 열리도록 수정했습니다!

위 스크린샷의 모달 내부의 데이터는 msw에서 받아오는 데이터입니다. dev 환경에서만 사용이 가능하기 때문에, 실제 배포시에는 모달의 api 연동 혹은 더미 데이터가 필요합니다!